### PR TITLE
Add TrainingPeaks MCP to Training tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Hacks and Mods around your Indoor Cycling Training, let´s make it even more fun
 ## Training tools
 
 - [Flux](https://github.com/dvmarinoff/Flux) - Indoor Cycling App for Structured Training.
+- [Sauce for Zwift](https://github.com/SauceLLC/sauce4zwift) - Overlay for Zwift with more metrics.
+- [TrainingPeaks MCP](https://github.com/JamsusMaximus/trainingpeaks-mcp) - Connect TrainingPeaks to AI assistants. Query CTL/ATL/TSB history, compare power data across seasons.
 - [Zwift on Linux](https://github.com/netbrain/zwift) - Docker image for Zwift on Linux.
 - [ZwiftPref](https://zwifthacks.com/zwiftpref/) - An app which helps you change settings for Zwift in the prefs.xml file in an easy and safe way.
-- [Sauce for Zwift](https://github.com/SauceLLC/sauce4zwift) - Overlay for Zwift with more metrics.
 
 ## Contributing
 


### PR DESCRIPTION
Adds TrainingPeaks MCP Server to the Training tools section (alphabetically sorted).

For indoor cyclists using TrainingPeaks, this enables natural language queries about training data:

- Historical fitness/fatigue trends (CTL/ATL/TSB)
- Power PR comparisons across seasons
- Training load patterns before peak performances

Works with Claude Desktop and other MCP-compatible assistants. No TrainingPeaks API approval needed.